### PR TITLE
Fix layout for model picker

### DIFF
--- a/src/components/chat/chat-topbar.tsx
+++ b/src/components/chat/chat-topbar.tsx
@@ -105,13 +105,13 @@ export default function ChatTopbar({
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="w-[170px] justify-between"
+            className="w-[300px] justify-between"
           >
             {currentModel || "Select model"}
             <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[170px] p-1">
+        <PopoverContent className="w-[300px] p-1">
           {models.length > 0 ? (
             models.map((model) => (
               <Button


### PR DESCRIPTION
This resolves a layout break caused when the model names are longer than the picker width