### PR TITLE
fix: infinite username loading skeleton

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -162,9 +162,18 @@ export default function Home() {
     }
   };
 
+  const onOpenChange = (isOpen: boolean) => { 
+    const username = localStorage.getItem("ollama_user")
+    if (username) return setOpen(isOpen)
+
+    localStorage.setItem("ollama_user", "Anonymous")
+    window.dispatchEvent(new Event("storage"))
+    setOpen(isOpen)
+  }
+  
   return (
     <main className="flex h-[calc(100dvh)] flex-col items-center ">
-      <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog open={open} onOpenChange={onOpenChange}>
         <ChatLayout
           chatId=""
           setSelectedModel={setSelectedModel}


### PR DESCRIPTION
when a user first opens the app, a welcome dialog that will also ask for the user name will appear. However when the user chooses to ignore the dialog and closes it without filling out the form, the username skeleton that located at the bottom of the sidebar will render indefinitely.

This PR will fix a bug with setting the default username to localstorage when the dialog is closed without username input.