### PR TITLE
fix: handle IME composition to prevent unintended submissions

### DIFF
--- a/src/components/chat/chat-bottombar.tsx
+++ b/src/components/chat/chat-bottombar.tsx
@@ -47,7 +47,7 @@ export default function ChatBottombar({
   const selectedModel = useChatStore((state) => state.selectedModel);
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSubmit(e as unknown as React.FormEvent<HTMLFormElement>);
     }


### PR DESCRIPTION
This PR resolves an issue where duplicate messages were sent when using IME for input in the chat interface. 

### Problem
When typing in languages like Korean, the `Enter` key press triggered message submission twice due to incomplete composition state. This caused:
1. Duplicate messages being sent.
2. Unnecessary re-renders of the chat component.


![Duplicate Message Issue with IME](https://github.com/user-attachments/assets/809cf301-db85-406d-a368-3f8d33b9a2e7)

### Solution
Added a condition to check `e.nativeEvent.isComposing` in the `handleKeyPress` function to ensure messages are only submitted after composition is complete.

### Changes
- Updated the `handleKeyPress` function to include a check for `!e.nativeEvent.isComposing`.

This fix improves the user experience when typing in languages that rely on IME, such as Korean or Japanese.

No other functionalities are affected.
