### PR TITLE
fix: code blocks now respect system theme preference

### DIFF
--- a/src/components/code-display-block.tsx
+++ b/src/components/code-display-block.tsx
@@ -13,7 +13,7 @@ interface ButtonCodeblockProps {
 export default function CodeDisplayBlock({ code }: ButtonCodeblockProps) {
   const [isCopied, setIsCopied] = useState(false);
   const isCopiedRef = useRef(false);
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
 
   const filteredCode = useMemo(
     () => code.split("\n").slice(1).join("\n") || code,
@@ -30,12 +30,14 @@ export default function CodeDisplayBlock({ code }: ButtonCodeblockProps) {
 
   const customStyle = useMemo(
     () =>
-      theme === "dark" ? { background: "#303033" } : { background: "#fcfcfc" },
-    [theme]
+      resolvedTheme === "dark"
+        ? { background: "#303033" }
+        : { background: "#fcfcfc" },
+    [resolvedTheme]
   );
   const codeTheme = useMemo(
-    () => (theme === "dark" ? dracula : github),
-    [theme]
+    () => (resolvedTheme === "dark" ? dracula : github),
+    [resolvedTheme]
   );
 
   const copyToClipboard = () => {


### PR DESCRIPTION
## Changes
This PR fixes the code block theme switching behavior when using system theme preference. It updates the theme detection logic to use `resolvedTheme` instead of `theme` from `next-themes`, ensuring proper dark mode detection when the theme is set to "system".

### Technical Changes
- Updated theme detection in `CodeDisplayBlock` component to use `resolvedTheme`
- Applied the fix to both background styling and syntax highlighting theme selection
- Ensures consistent theme behavior across the application

### Testing
- Verified code block appearance in:
  - Explicit light mode
  - Explicit dark mode
  - System theme with system light mode
  - System theme with system dark mode

Fixes #120